### PR TITLE
browsers: fix default browser

### DIFF
--- a/homes/michal/mimelist.nix
+++ b/homes/michal/mimelist.nix
@@ -1,4 +1,5 @@
 # Query with `xdg-mime query default image/png`
+# mimeApps settings are also set in browser nix module
 let
   editor = "code.desktop";
   file-manager = "org.gnome.Nautilus.desktop";

--- a/modules/gui-packages/browser/chrome.nix
+++ b/modules/gui-packages/browser/chrome.nix
@@ -6,18 +6,19 @@
 }: let
   cfg = config.michal.browsers.chrome;
   mkBrowserOptions = import ./options.nix;
+  package = pkgs.google-chrome;
 in {
   options.michal.browsers.chrome = mkBrowserOptions {
-    inherit lib;
+    inherit lib package;
     humanName = "google chrome";
     execName = "google-chrome";
   };
 
   config = lib.mkIf cfg.enable {
     environment.systemPackages = with pkgs; [
+      package
       libsForQt5.plasma-browser-integration
-      google-chrome
-      (pkgs.writeShellScriptBin "google-chrome" "exec -a $0 ${google-chrome}/bin/google-chrome-stable $@")
+      (pkgs.writeShellScriptBin "google-chrome" "exec -a $0 ${package}/bin/google-chrome-stable $@")
     ];
 
     # Theme: `rm -fr /etc/opt/chrome/policies/managed/` helped delete old color theme.

--- a/modules/gui-packages/browser/default.nix
+++ b/modules/gui-packages/browser/default.nix
@@ -20,9 +20,10 @@ in {
     };
 
     home-manager.users.${username} = {
+      # Verify with `xdg-mime query default x-scheme-handler/http`
       xdg.mimeApps = {
         defaultApplications = let
-          browser = defaultBrowser.desktopFile;
+          browser = defaultBrowser.desktopFileName;
         in {
           "default-web-browser" = browser;
           "x-scheme-handler/http" = browser;
@@ -38,6 +39,10 @@ in {
       {
         assertion = lib.length defaultBrowsers <= 1;
         message = "You have more than one default browsers: ${lib.concatStringsSep " " (lib.map (br: br.name) defaultBrowsers)}";
+      }
+      {
+        assertion = lib.length defaultBrowsers == 1;
+        message = "You have one default browsers: ${lib.concatStringsSep " " (lib.map (br: br.name) defaultBrowsers)}";
       }
     ];
   };

--- a/modules/gui-packages/browser/firefox.nix
+++ b/modules/gui-packages/browser/firefox.nix
@@ -10,6 +10,7 @@ in {
   options.michal.browsers.firefox = mkBrowserOptions {
     inherit lib;
     execName = "firefox";
+    desktopFileName = pkgs.firefox.desktopItem.name;
   };
 
   config = lib.mkIf cfg.enable {

--- a/modules/gui-packages/browser/options.nix
+++ b/modules/gui-packages/browser/options.nix
@@ -2,6 +2,8 @@
   lib,
   humanName ? execName,
   execName,
+  package ? null,
+  desktopFileName ? package.meta.desktopFile,
 }:
 with lib; {
   enable = mkEnableOption "${humanName} browser";
@@ -10,8 +12,8 @@ with lib; {
     type = types.str;
     default = execName;
   };
-  desktopFile = mkOption {
+  desktopFileName = mkOption {
     type = types.str;
-    default = "${execName}.desktop";
+    default = desktopFileName;
   };
 }

--- a/modules/gui-packages/browser/zen.nix
+++ b/modules/gui-packages/browser/zen.nix
@@ -7,15 +7,17 @@
 }: let
   cfg = config.michal.browsers.zen;
   mkBrowserOptions = import ./options.nix;
+  zen-package = inputs.zen-browser.packages."${pkgs.system}".default;
 in {
   options.michal.browsers.zen = mkBrowserOptions {
     inherit lib;
     execName = "zen";
+    package = zen-package;
   };
 
   config = lib.mkIf cfg.enable {
     environment.systemPackages = [
-      inputs.zen-browser.packages."${pkgs.system}".default
+      zen-package
     ];
   };
 }

--- a/modules/ssh.nix
+++ b/modules/ssh.nix
@@ -120,7 +120,6 @@ in {
 
     environment.systemPackages = with pkgs; [
       gnome-keyring
-      lemonade # copy, xdg-open over SSH
     ];
 
     services.gnome.gnome-keyring.enable = true;


### PR DESCRIPTION
### TL;DR

Fixed browser default application handling and improved desktop file name resolution.

### What changed?

- Added a comment in `mimelist.nix` noting that mimeApps settings are also set in the browser module
- Refactored browser modules to use a consistent approach for desktop file names:
  - Added `package` parameter to browser options
  - Renamed `desktopFile` to `desktopFileName` for clarity
  - Made desktop file name resolution more robust by deriving from package metadata
- Added an assertion to ensure exactly one default browser is configured
- Removed `lemonade` package from SSH module
- Added a comment to help verify default browser settings

### How to test?

1. Verify default browser settings with `xdg-mime query default x-scheme-handler/http`
2. Check that browser desktop files are correctly referenced in mime associations
3. Ensure browser applications launch correctly when clicking links

### Why make this change?

This change improves the reliability of browser default application handling by using a more consistent approach to desktop file name resolution. It also adds helpful comments and assertions to make the configuration more maintainable and easier to debug.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a positive confirmation message when exactly one default browser is set.
  - Introduced a new attribute for Firefox browser configuration to specify the desktop file name.

- **Refactor**
  - Unified and clarified browser package references for Chrome and Zen browsers.
  - Updated browser options to use dynamic desktop file name resolution based on package metadata.
  - Renamed browser option from `desktopFile` to `desktopFileName` for improved clarity.

- **Chores**
  - Removed the `lemonade` package from the system packages list.
  - Added and updated comments for improved documentation and guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->